### PR TITLE
[tk390] Tratamento de upload e download de arquivo grandes

### DIFF
--- a/grpc_ssm/grpc_client_test.py
+++ b/grpc_ssm/grpc_client_test.py
@@ -6,6 +6,7 @@ import time
 import grpc
 
 import opac_pb2
+import opac_pb2_grpc
 
 SLEEP_TIME = 5
 
@@ -17,7 +18,7 @@ def run():
 
     channel = grpc.insecure_channel('localhost:5000')
 
-    stubAsset = opac_pb2.AssetServiceStub(channel)
+    stubAsset = opac_pb2_grpc.AssetServiceStub(channel)
 
     ###########################################################################
     # Teste asset.add_asset
@@ -56,6 +57,52 @@ def run():
     print("Agora vou verificando o estado da task: %s, %s" % (task.id, task_state))
 
     ###########################################################################
+    # Teste asset.get_asset (large file)
+    ###########################################################################
+
+    asset = stubAsset.get_asset(opac_pb2.TaskId(id=task.id))
+
+    print("Retornando os dados do Asset: ")
+
+    print((task.id, task_state.state, task_info.url, task_info.url_path, asset))
+
+    ###########################################################################
+    # Teste asset.add_asset (large file)
+    ###########################################################################
+
+    print("Obtendo o arquivo para ser enviado pelo GRPC")
+
+    file = open('large_sample.txt', 'rb')
+
+    meta = '{"foo": "bar", "pickles": "blaus"}'  # String
+
+    print("Envida os metadados %s como param metadata." % meta)
+
+    task = stubAsset.add_asset(
+        opac_pb2.Asset(file='', filename='artigo.txt',
+                       type="txt", metadata=meta,
+                       bucket="Bucket Sample",
+                       large_file_path='artigo.txt'))
+
+    ###########################################################################
+    # Teste asset.get_task_state (large file)
+    ###########################################################################
+
+    print("ID da task: %s" % task.id)
+
+    task_state = stubAsset.get_task_state(opac_pb2.TaskId(id=task.id))
+
+    print("Verificando o estado da task: %s" % task_state)
+
+    print("Dormindo por %s segundos..." % SLEEP_TIME)
+
+    time.sleep(SLEEP_TIME)  # sleep 10 seconds
+
+    task_state = stubAsset.get_task_state(opac_pb2.TaskId(id=task.id))
+
+    print("Agora vou verificando o estado da task: %s, %s" % (task.id, task_state))
+
+    ###########################################################################
     # Teste asset.get_asset_info
     ###########################################################################
 
@@ -64,7 +111,7 @@ def run():
     print("Informações da url do asset: %s" % task_info)
 
     ###########################################################################
-    # Teste asset.get_asset
+    # Teste asset.get_asset (large file)
     ###########################################################################
 
     asset = stubAsset.get_asset(opac_pb2.TaskId(id=task.id))
@@ -207,6 +254,7 @@ def run():
     time.sleep(SLEEP_TIME)
 
     task = stubBucket.remove_bucket(opac_pb2.BucketName(name="Bucket Sample"))
+
 
 if __name__ == '__main__':
     run()

--- a/grpc_ssm/opac.proto
+++ b/grpc_ssm/opac.proto
@@ -3,6 +3,8 @@ syntax = "proto3";
 service AssetService {
     rpc get_asset(TaskId) returns (Asset) {}
     rpc add_asset(Asset) returns (TaskId) {}
+    rpc upload_file(stream File) returns (Reply) {}
+    rpc download_file(Request) returns (stream File) {}
     rpc update_asset(Asset) returns (TaskId) {}
     rpc remove_asset(TaskId) returns (AssetRemoved) {}
     rpc exists_asset(TaskId) returns (AssetExists) {}
@@ -32,6 +34,19 @@ message Asset {
     string full_absolute_url = 9;
     string created_at = 10;
     string updated_at = 11;
+    string large_file_path = 12;
+}
+
+message File {
+    bytes file = 1; // file of the asset
+}
+
+message Request {
+  string large_file_path = 1;
+}
+
+message Reply {
+  string large_file_path = 1;
 }
 
 message Assets{

--- a/grpc_ssm/opac_pb2.py
+++ b/grpc_ssm/opac_pb2.py
@@ -7,7 +7,6 @@ from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
 from google.protobuf import symbol_database as _symbol_database
-from google.protobuf import descriptor_pb2
 # @@protoc_insertion_point(imports)
 
 _sym_db = _symbol_database.Default()
@@ -19,7 +18,8 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='opac.proto',
   package='',
   syntax='proto3',
-  serialized_pb=_b('\n\nopac.proto\"\xd0\x01\n\x05\x41sset\x12\x0c\n\x04\x66ile\x18\x01 \x01(\x0c\x12\x10\n\x08\x66ilename\x18\x02 \x01(\t\x12\x0c\n\x04type\x18\x03 \x01(\t\x12\x10\n\x08metadata\x18\x04 \x01(\t\x12\x0c\n\x04uuid\x18\x05 \x01(\t\x12\x0e\n\x06\x62ucket\x18\x06 \x01(\t\x12\x10\n\x08\x63hecksum\x18\x07 \x01(\t\x12\x14\n\x0c\x61\x62solute_url\x18\x08 \x01(\t\x12\x19\n\x11\x66ull_absolute_url\x18\t \x01(\t\x12\x12\n\ncreated_at\x18\n \x01(\t\x12\x12\n\nupdated_at\x18\x0b \x01(\t\" \n\x06\x41ssets\x12\x16\n\x06\x61ssets\x18\x01 \x03(\x0b\x32\x06.Asset\"*\n\tAssetInfo\x12\x0b\n\x03url\x18\x01 \x01(\t\x12\x10\n\x08url_path\x18\x02 \x01(\t\"\x1d\n\x0c\x41ssetRemoved\x12\r\n\x05\x65xist\x18\x01 \x01(\x08\"\x1c\n\x0b\x41ssetExists\x12\r\n\x05\x65xist\x18\x01 \x01(\x08\"\x14\n\x06TaskId\x12\n\n\x02id\x18\x01 \x01(\t\"\x1a\n\tTaskState\x12\r\n\x05state\x18\x01 \x01(\t\"\x16\n\x06\x42ucket\x12\x0c\n\x04name\x18\x01 \x01(\t\",\n\nBucketName\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x10\n\x08new_name\x18\x02 \x01(\t\"\x1d\n\x0c\x42ucketExists\x12\r\n\x05\x65xist\x18\x01 \x01(\x08\"\x1e\n\rBucketRemoved\x12\r\n\x05\x65xist\x18\x01 \x01(\x08\x32\xd4\x02\n\x0c\x41ssetService\x12\x1e\n\tget_asset\x12\x07.TaskId\x1a\x06.Asset\"\x00\x12\x1e\n\tadd_asset\x12\x06.Asset\x1a\x07.TaskId\"\x00\x12!\n\x0cupdate_asset\x12\x06.Asset\x1a\x07.TaskId\"\x00\x12(\n\x0cremove_asset\x12\x07.TaskId\x1a\r.AssetRemoved\"\x00\x12\'\n\x0c\x65xists_asset\x12\x07.TaskId\x1a\x0c.AssetExists\"\x00\x12\'\n\x0eget_asset_info\x12\x07.TaskId\x1a\n.AssetInfo\"\x00\x12\'\n\x0eget_task_state\x12\x07.TaskId\x1a\n.TaskState\"\x00\x12 \n\nget_bucket\x12\x07.TaskId\x1a\x07.Bucket\"\x00\x12\x1a\n\x05query\x12\x06.Asset\x1a\x07.Assets\"\x00\x32\xe3\x01\n\rBucketService\x12$\n\nadd_bucket\x12\x0b.BucketName\x1a\x07.TaskId\"\x00\x12\'\n\rupdate_bucket\x12\x0b.BucketName\x1a\x07.TaskId\"\x00\x12.\n\rremove_bucket\x12\x0b.BucketName\x1a\x0e.BucketRemoved\"\x00\x12-\n\rexists_bucket\x12\x0b.BucketName\x1a\r.BucketExists\"\x00\x12$\n\nget_assets\x12\x0b.BucketName\x1a\x07.Assets\"\x00\x62\x06proto3')
+  serialized_options=None,
+  serialized_pb=_b('\n\nopac.proto\"\xe9\x01\n\x05\x41sset\x12\x0c\n\x04\x66ile\x18\x01 \x01(\x0c\x12\x10\n\x08\x66ilename\x18\x02 \x01(\t\x12\x0c\n\x04type\x18\x03 \x01(\t\x12\x10\n\x08metadata\x18\x04 \x01(\t\x12\x0c\n\x04uuid\x18\x05 \x01(\t\x12\x0e\n\x06\x62ucket\x18\x06 \x01(\t\x12\x10\n\x08\x63hecksum\x18\x07 \x01(\t\x12\x14\n\x0c\x61\x62solute_url\x18\x08 \x01(\t\x12\x19\n\x11\x66ull_absolute_url\x18\t \x01(\t\x12\x12\n\ncreated_at\x18\n \x01(\t\x12\x12\n\nupdated_at\x18\x0b \x01(\t\x12\x17\n\x0flarge_file_path\x18\x0c \x01(\t\"\x14\n\x04\x46ile\x12\x0c\n\x04\x66ile\x18\x01 \x01(\x0c\"\"\n\x07Request\x12\x17\n\x0flarge_file_path\x18\x01 \x01(\t\" \n\x05Reply\x12\x17\n\x0flarge_file_path\x18\x01 \x01(\t\" \n\x06\x41ssets\x12\x16\n\x06\x61ssets\x18\x01 \x03(\x0b\x32\x06.Asset\"*\n\tAssetInfo\x12\x0b\n\x03url\x18\x01 \x01(\t\x12\x10\n\x08url_path\x18\x02 \x01(\t\"\x1d\n\x0c\x41ssetRemoved\x12\r\n\x05\x65xist\x18\x01 \x01(\x08\"\x1c\n\x0b\x41ssetExists\x12\r\n\x05\x65xist\x18\x01 \x01(\x08\"\x14\n\x06TaskId\x12\n\n\x02id\x18\x01 \x01(\t\"\x1a\n\tTaskState\x12\r\n\x05state\x18\x01 \x01(\t\"\x16\n\x06\x42ucket\x12\x0c\n\x04name\x18\x01 \x01(\t\",\n\nBucketName\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x10\n\x08new_name\x18\x02 \x01(\t\"\x1d\n\x0c\x42ucketExists\x12\r\n\x05\x65xist\x18\x01 \x01(\x08\"\x1e\n\rBucketRemoved\x12\r\n\x05\x65xist\x18\x01 \x01(\x08\x32\x9c\x03\n\x0c\x41ssetService\x12\x1e\n\tget_asset\x12\x07.TaskId\x1a\x06.Asset\"\x00\x12\x1e\n\tadd_asset\x12\x06.Asset\x1a\x07.TaskId\"\x00\x12 \n\x0bupload_file\x12\x05.File\x1a\x06.Reply\"\x00(\x01\x12$\n\rdownload_file\x12\x08.Request\x1a\x05.File\"\x00\x30\x01\x12!\n\x0cupdate_asset\x12\x06.Asset\x1a\x07.TaskId\"\x00\x12(\n\x0cremove_asset\x12\x07.TaskId\x1a\r.AssetRemoved\"\x00\x12\'\n\x0c\x65xists_asset\x12\x07.TaskId\x1a\x0c.AssetExists\"\x00\x12\'\n\x0eget_asset_info\x12\x07.TaskId\x1a\n.AssetInfo\"\x00\x12\'\n\x0eget_task_state\x12\x07.TaskId\x1a\n.TaskState\"\x00\x12 \n\nget_bucket\x12\x07.TaskId\x1a\x07.Bucket\"\x00\x12\x1a\n\x05query\x12\x06.Asset\x1a\x07.Assets\"\x00\x32\xe3\x01\n\rBucketService\x12$\n\nadd_bucket\x12\x0b.BucketName\x1a\x07.TaskId\"\x00\x12\'\n\rupdate_bucket\x12\x0b.BucketName\x1a\x07.TaskId\"\x00\x12.\n\rremove_bucket\x12\x0b.BucketName\x1a\x0e.BucketRemoved\"\x00\x12-\n\rexists_bucket\x12\x0b.BucketName\x1a\r.BucketExists\"\x00\x12$\n\nget_assets\x12\x0b.BucketName\x1a\x07.Assets\"\x00\x62\x06proto3')
 )
 
 
@@ -38,91 +38,191 @@ _ASSET = _descriptor.Descriptor(
       has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='filename', full_name='Asset.filename', index=1,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='type', full_name='Asset.type', index=2,
       number=3, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='metadata', full_name='Asset.metadata', index=3,
       number=4, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='uuid', full_name='Asset.uuid', index=4,
       number=5, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='bucket', full_name='Asset.bucket', index=5,
       number=6, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='checksum', full_name='Asset.checksum', index=6,
       number=7, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='absolute_url', full_name='Asset.absolute_url', index=7,
       number=8, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='full_absolute_url', full_name='Asset.full_absolute_url', index=8,
       number=9, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='created_at', full_name='Asset.created_at', index=9,
       number=10, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='updated_at', full_name='Asset.updated_at', index=10,
       number=11, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='large_file_path', full_name='Asset.large_file_path', index=11,
+      number=12, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
   oneofs=[
   ],
   serialized_start=15,
-  serialized_end=223,
+  serialized_end=248,
+)
+
+
+_FILE = _descriptor.Descriptor(
+  name='File',
+  full_name='File',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='file', full_name='File.file', index=0,
+      number=1, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b(""),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=250,
+  serialized_end=270,
+)
+
+
+_REQUEST = _descriptor.Descriptor(
+  name='Request',
+  full_name='Request',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='large_file_path', full_name='Request.large_file_path', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=272,
+  serialized_end=306,
+)
+
+
+_REPLY = _descriptor.Descriptor(
+  name='Reply',
+  full_name='Reply',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='large_file_path', full_name='Reply.large_file_path', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=308,
+  serialized_end=340,
 )
 
 
@@ -139,21 +239,21 @@ _ASSETS = _descriptor.Descriptor(
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=225,
-  serialized_end=257,
+  serialized_start=342,
+  serialized_end=374,
 )
 
 
@@ -170,28 +270,28 @@ _ASSETINFO = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='url_path', full_name='AssetInfo.url_path', index=1,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=259,
-  serialized_end=301,
+  serialized_start=376,
+  serialized_end=418,
 )
 
 
@@ -208,21 +308,21 @@ _ASSETREMOVED = _descriptor.Descriptor(
       has_default_value=False, default_value=False,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=303,
-  serialized_end=332,
+  serialized_start=420,
+  serialized_end=449,
 )
 
 
@@ -239,21 +339,21 @@ _ASSETEXISTS = _descriptor.Descriptor(
       has_default_value=False, default_value=False,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=334,
-  serialized_end=362,
+  serialized_start=451,
+  serialized_end=479,
 )
 
 
@@ -270,21 +370,21 @@ _TASKID = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=364,
-  serialized_end=384,
+  serialized_start=481,
+  serialized_end=501,
 )
 
 
@@ -301,21 +401,21 @@ _TASKSTATE = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=386,
-  serialized_end=412,
+  serialized_start=503,
+  serialized_end=529,
 )
 
 
@@ -332,21 +432,21 @@ _BUCKET = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=414,
-  serialized_end=436,
+  serialized_start=531,
+  serialized_end=553,
 )
 
 
@@ -363,28 +463,28 @@ _BUCKETNAME = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='new_name', full_name='BucketName.new_name', index=1,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=438,
-  serialized_end=482,
+  serialized_start=555,
+  serialized_end=599,
 )
 
 
@@ -401,21 +501,21 @@ _BUCKETEXISTS = _descriptor.Descriptor(
       has_default_value=False, default_value=False,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=484,
-  serialized_end=513,
+  serialized_start=601,
+  serialized_end=630,
 )
 
 
@@ -432,25 +532,28 @@ _BUCKETREMOVED = _descriptor.Descriptor(
       has_default_value=False, default_value=False,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      options=None),
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
   ],
-  options=None,
+  serialized_options=None,
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=515,
-  serialized_end=545,
+  serialized_start=632,
+  serialized_end=662,
 )
 
 _ASSETS.fields_by_name['assets'].message_type = _ASSET
 DESCRIPTOR.message_types_by_name['Asset'] = _ASSET
+DESCRIPTOR.message_types_by_name['File'] = _FILE
+DESCRIPTOR.message_types_by_name['Request'] = _REQUEST
+DESCRIPTOR.message_types_by_name['Reply'] = _REPLY
 DESCRIPTOR.message_types_by_name['Assets'] = _ASSETS
 DESCRIPTOR.message_types_by_name['AssetInfo'] = _ASSETINFO
 DESCRIPTOR.message_types_by_name['AssetRemoved'] = _ASSETREMOVED
@@ -469,6 +572,27 @@ Asset = _reflection.GeneratedProtocolMessageType('Asset', (_message.Message,), d
   # @@protoc_insertion_point(class_scope:Asset)
   ))
 _sym_db.RegisterMessage(Asset)
+
+File = _reflection.GeneratedProtocolMessageType('File', (_message.Message,), dict(
+  DESCRIPTOR = _FILE,
+  __module__ = 'opac_pb2'
+  # @@protoc_insertion_point(class_scope:File)
+  ))
+_sym_db.RegisterMessage(File)
+
+Request = _reflection.GeneratedProtocolMessageType('Request', (_message.Message,), dict(
+  DESCRIPTOR = _REQUEST,
+  __module__ = 'opac_pb2'
+  # @@protoc_insertion_point(class_scope:Request)
+  ))
+_sym_db.RegisterMessage(Request)
+
+Reply = _reflection.GeneratedProtocolMessageType('Reply', (_message.Message,), dict(
+  DESCRIPTOR = _REPLY,
+  __module__ = 'opac_pb2'
+  # @@protoc_insertion_point(class_scope:Reply)
+  ))
+_sym_db.RegisterMessage(Reply)
 
 Assets = _reflection.GeneratedProtocolMessageType('Assets', (_message.Message,), dict(
   DESCRIPTOR = _ASSETS,
@@ -541,616 +665,178 @@ BucketRemoved = _reflection.GeneratedProtocolMessageType('BucketRemoved', (_mess
 _sym_db.RegisterMessage(BucketRemoved)
 
 
-try:
-  # THESE ELEMENTS WILL BE DEPRECATED.
-  # Please use the generated *_pb2_grpc.py files instead.
-  import grpc
-  from grpc.beta import implementations as beta_implementations
-  from grpc.beta import interfaces as beta_interfaces
-  from grpc.framework.common import cardinality
-  from grpc.framework.interfaces.face import utilities as face_utilities
+
+_ASSETSERVICE = _descriptor.ServiceDescriptor(
+  name='AssetService',
+  full_name='AssetService',
+  file=DESCRIPTOR,
+  index=0,
+  serialized_options=None,
+  serialized_start=665,
+  serialized_end=1077,
+  methods=[
+  _descriptor.MethodDescriptor(
+    name='get_asset',
+    full_name='AssetService.get_asset',
+    index=0,
+    containing_service=None,
+    input_type=_TASKID,
+    output_type=_ASSET,
+    serialized_options=None,
+  ),
+  _descriptor.MethodDescriptor(
+    name='add_asset',
+    full_name='AssetService.add_asset',
+    index=1,
+    containing_service=None,
+    input_type=_ASSET,
+    output_type=_TASKID,
+    serialized_options=None,
+  ),
+  _descriptor.MethodDescriptor(
+    name='upload_file',
+    full_name='AssetService.upload_file',
+    index=2,
+    containing_service=None,
+    input_type=_FILE,
+    output_type=_REPLY,
+    serialized_options=None,
+  ),
+  _descriptor.MethodDescriptor(
+    name='download_file',
+    full_name='AssetService.download_file',
+    index=3,
+    containing_service=None,
+    input_type=_REQUEST,
+    output_type=_FILE,
+    serialized_options=None,
+  ),
+  _descriptor.MethodDescriptor(
+    name='update_asset',
+    full_name='AssetService.update_asset',
+    index=4,
+    containing_service=None,
+    input_type=_ASSET,
+    output_type=_TASKID,
+    serialized_options=None,
+  ),
+  _descriptor.MethodDescriptor(
+    name='remove_asset',
+    full_name='AssetService.remove_asset',
+    index=5,
+    containing_service=None,
+    input_type=_TASKID,
+    output_type=_ASSETREMOVED,
+    serialized_options=None,
+  ),
+  _descriptor.MethodDescriptor(
+    name='exists_asset',
+    full_name='AssetService.exists_asset',
+    index=6,
+    containing_service=None,
+    input_type=_TASKID,
+    output_type=_ASSETEXISTS,
+    serialized_options=None,
+  ),
+  _descriptor.MethodDescriptor(
+    name='get_asset_info',
+    full_name='AssetService.get_asset_info',
+    index=7,
+    containing_service=None,
+    input_type=_TASKID,
+    output_type=_ASSETINFO,
+    serialized_options=None,
+  ),
+  _descriptor.MethodDescriptor(
+    name='get_task_state',
+    full_name='AssetService.get_task_state',
+    index=8,
+    containing_service=None,
+    input_type=_TASKID,
+    output_type=_TASKSTATE,
+    serialized_options=None,
+  ),
+  _descriptor.MethodDescriptor(
+    name='get_bucket',
+    full_name='AssetService.get_bucket',
+    index=9,
+    containing_service=None,
+    input_type=_TASKID,
+    output_type=_BUCKET,
+    serialized_options=None,
+  ),
+  _descriptor.MethodDescriptor(
+    name='query',
+    full_name='AssetService.query',
+    index=10,
+    containing_service=None,
+    input_type=_ASSET,
+    output_type=_ASSETS,
+    serialized_options=None,
+  ),
+])
+_sym_db.RegisterServiceDescriptor(_ASSETSERVICE)
+
+DESCRIPTOR.services_by_name['AssetService'] = _ASSETSERVICE
 
 
-  class AssetServiceStub(object):
-    # missing associated documentation comment in .proto file
-    pass
+_BUCKETSERVICE = _descriptor.ServiceDescriptor(
+  name='BucketService',
+  full_name='BucketService',
+  file=DESCRIPTOR,
+  index=1,
+  serialized_options=None,
+  serialized_start=1080,
+  serialized_end=1307,
+  methods=[
+  _descriptor.MethodDescriptor(
+    name='add_bucket',
+    full_name='BucketService.add_bucket',
+    index=0,
+    containing_service=None,
+    input_type=_BUCKETNAME,
+    output_type=_TASKID,
+    serialized_options=None,
+  ),
+  _descriptor.MethodDescriptor(
+    name='update_bucket',
+    full_name='BucketService.update_bucket',
+    index=1,
+    containing_service=None,
+    input_type=_BUCKETNAME,
+    output_type=_TASKID,
+    serialized_options=None,
+  ),
+  _descriptor.MethodDescriptor(
+    name='remove_bucket',
+    full_name='BucketService.remove_bucket',
+    index=2,
+    containing_service=None,
+    input_type=_BUCKETNAME,
+    output_type=_BUCKETREMOVED,
+    serialized_options=None,
+  ),
+  _descriptor.MethodDescriptor(
+    name='exists_bucket',
+    full_name='BucketService.exists_bucket',
+    index=3,
+    containing_service=None,
+    input_type=_BUCKETNAME,
+    output_type=_BUCKETEXISTS,
+    serialized_options=None,
+  ),
+  _descriptor.MethodDescriptor(
+    name='get_assets',
+    full_name='BucketService.get_assets',
+    index=4,
+    containing_service=None,
+    input_type=_BUCKETNAME,
+    output_type=_ASSETS,
+    serialized_options=None,
+  ),
+])
+_sym_db.RegisterServiceDescriptor(_BUCKETSERVICE)
 
-    def __init__(self, channel):
-      """Constructor.
+DESCRIPTOR.services_by_name['BucketService'] = _BUCKETSERVICE
 
-      Args:
-        channel: A grpc.Channel.
-      """
-      self.get_asset = channel.unary_unary(
-          '/AssetService/get_asset',
-          request_serializer=TaskId.SerializeToString,
-          response_deserializer=Asset.FromString,
-          )
-      self.add_asset = channel.unary_unary(
-          '/AssetService/add_asset',
-          request_serializer=Asset.SerializeToString,
-          response_deserializer=TaskId.FromString,
-          )
-      self.update_asset = channel.unary_unary(
-          '/AssetService/update_asset',
-          request_serializer=Asset.SerializeToString,
-          response_deserializer=TaskId.FromString,
-          )
-      self.remove_asset = channel.unary_unary(
-          '/AssetService/remove_asset',
-          request_serializer=TaskId.SerializeToString,
-          response_deserializer=AssetRemoved.FromString,
-          )
-      self.exists_asset = channel.unary_unary(
-          '/AssetService/exists_asset',
-          request_serializer=TaskId.SerializeToString,
-          response_deserializer=AssetExists.FromString,
-          )
-      self.get_asset_info = channel.unary_unary(
-          '/AssetService/get_asset_info',
-          request_serializer=TaskId.SerializeToString,
-          response_deserializer=AssetInfo.FromString,
-          )
-      self.get_task_state = channel.unary_unary(
-          '/AssetService/get_task_state',
-          request_serializer=TaskId.SerializeToString,
-          response_deserializer=TaskState.FromString,
-          )
-      self.get_bucket = channel.unary_unary(
-          '/AssetService/get_bucket',
-          request_serializer=TaskId.SerializeToString,
-          response_deserializer=Bucket.FromString,
-          )
-      self.query = channel.unary_unary(
-          '/AssetService/query',
-          request_serializer=Asset.SerializeToString,
-          response_deserializer=Assets.FromString,
-          )
-
-
-  class AssetServiceServicer(object):
-    # missing associated documentation comment in .proto file
-    pass
-
-    def get_asset(self, request, context):
-      # missing associated documentation comment in .proto file
-      pass
-      context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-      context.set_details('Method not implemented!')
-      raise NotImplementedError('Method not implemented!')
-
-    def add_asset(self, request, context):
-      # missing associated documentation comment in .proto file
-      pass
-      context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-      context.set_details('Method not implemented!')
-      raise NotImplementedError('Method not implemented!')
-
-    def update_asset(self, request, context):
-      # missing associated documentation comment in .proto file
-      pass
-      context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-      context.set_details('Method not implemented!')
-      raise NotImplementedError('Method not implemented!')
-
-    def remove_asset(self, request, context):
-      # missing associated documentation comment in .proto file
-      pass
-      context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-      context.set_details('Method not implemented!')
-      raise NotImplementedError('Method not implemented!')
-
-    def exists_asset(self, request, context):
-      # missing associated documentation comment in .proto file
-      pass
-      context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-      context.set_details('Method not implemented!')
-      raise NotImplementedError('Method not implemented!')
-
-    def get_asset_info(self, request, context):
-      # missing associated documentation comment in .proto file
-      pass
-      context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-      context.set_details('Method not implemented!')
-      raise NotImplementedError('Method not implemented!')
-
-    def get_task_state(self, request, context):
-      # missing associated documentation comment in .proto file
-      pass
-      context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-      context.set_details('Method not implemented!')
-      raise NotImplementedError('Method not implemented!')
-
-    def get_bucket(self, request, context):
-      # missing associated documentation comment in .proto file
-      pass
-      context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-      context.set_details('Method not implemented!')
-      raise NotImplementedError('Method not implemented!')
-
-    def query(self, request, context):
-      # missing associated documentation comment in .proto file
-      pass
-      context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-      context.set_details('Method not implemented!')
-      raise NotImplementedError('Method not implemented!')
-
-
-  def add_AssetServiceServicer_to_server(servicer, server):
-    rpc_method_handlers = {
-        'get_asset': grpc.unary_unary_rpc_method_handler(
-            servicer.get_asset,
-            request_deserializer=TaskId.FromString,
-            response_serializer=Asset.SerializeToString,
-        ),
-        'add_asset': grpc.unary_unary_rpc_method_handler(
-            servicer.add_asset,
-            request_deserializer=Asset.FromString,
-            response_serializer=TaskId.SerializeToString,
-        ),
-        'update_asset': grpc.unary_unary_rpc_method_handler(
-            servicer.update_asset,
-            request_deserializer=Asset.FromString,
-            response_serializer=TaskId.SerializeToString,
-        ),
-        'remove_asset': grpc.unary_unary_rpc_method_handler(
-            servicer.remove_asset,
-            request_deserializer=TaskId.FromString,
-            response_serializer=AssetRemoved.SerializeToString,
-        ),
-        'exists_asset': grpc.unary_unary_rpc_method_handler(
-            servicer.exists_asset,
-            request_deserializer=TaskId.FromString,
-            response_serializer=AssetExists.SerializeToString,
-        ),
-        'get_asset_info': grpc.unary_unary_rpc_method_handler(
-            servicer.get_asset_info,
-            request_deserializer=TaskId.FromString,
-            response_serializer=AssetInfo.SerializeToString,
-        ),
-        'get_task_state': grpc.unary_unary_rpc_method_handler(
-            servicer.get_task_state,
-            request_deserializer=TaskId.FromString,
-            response_serializer=TaskState.SerializeToString,
-        ),
-        'get_bucket': grpc.unary_unary_rpc_method_handler(
-            servicer.get_bucket,
-            request_deserializer=TaskId.FromString,
-            response_serializer=Bucket.SerializeToString,
-        ),
-        'query': grpc.unary_unary_rpc_method_handler(
-            servicer.query,
-            request_deserializer=Asset.FromString,
-            response_serializer=Assets.SerializeToString,
-        ),
-    }
-    generic_handler = grpc.method_handlers_generic_handler(
-        'AssetService', rpc_method_handlers)
-    server.add_generic_rpc_handlers((generic_handler,))
-
-
-  class BucketServiceStub(object):
-    # missing associated documentation comment in .proto file
-    pass
-
-    def __init__(self, channel):
-      """Constructor.
-
-      Args:
-        channel: A grpc.Channel.
-      """
-      self.add_bucket = channel.unary_unary(
-          '/BucketService/add_bucket',
-          request_serializer=BucketName.SerializeToString,
-          response_deserializer=TaskId.FromString,
-          )
-      self.update_bucket = channel.unary_unary(
-          '/BucketService/update_bucket',
-          request_serializer=BucketName.SerializeToString,
-          response_deserializer=TaskId.FromString,
-          )
-      self.remove_bucket = channel.unary_unary(
-          '/BucketService/remove_bucket',
-          request_serializer=BucketName.SerializeToString,
-          response_deserializer=BucketRemoved.FromString,
-          )
-      self.exists_bucket = channel.unary_unary(
-          '/BucketService/exists_bucket',
-          request_serializer=BucketName.SerializeToString,
-          response_deserializer=BucketExists.FromString,
-          )
-      self.get_assets = channel.unary_unary(
-          '/BucketService/get_assets',
-          request_serializer=BucketName.SerializeToString,
-          response_deserializer=Assets.FromString,
-          )
-
-
-  class BucketServiceServicer(object):
-    # missing associated documentation comment in .proto file
-    pass
-
-    def add_bucket(self, request, context):
-      # missing associated documentation comment in .proto file
-      pass
-      context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-      context.set_details('Method not implemented!')
-      raise NotImplementedError('Method not implemented!')
-
-    def update_bucket(self, request, context):
-      # missing associated documentation comment in .proto file
-      pass
-      context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-      context.set_details('Method not implemented!')
-      raise NotImplementedError('Method not implemented!')
-
-    def remove_bucket(self, request, context):
-      # missing associated documentation comment in .proto file
-      pass
-      context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-      context.set_details('Method not implemented!')
-      raise NotImplementedError('Method not implemented!')
-
-    def exists_bucket(self, request, context):
-      # missing associated documentation comment in .proto file
-      pass
-      context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-      context.set_details('Method not implemented!')
-      raise NotImplementedError('Method not implemented!')
-
-    def get_assets(self, request, context):
-      # missing associated documentation comment in .proto file
-      pass
-      context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-      context.set_details('Method not implemented!')
-      raise NotImplementedError('Method not implemented!')
-
-
-  def add_BucketServiceServicer_to_server(servicer, server):
-    rpc_method_handlers = {
-        'add_bucket': grpc.unary_unary_rpc_method_handler(
-            servicer.add_bucket,
-            request_deserializer=BucketName.FromString,
-            response_serializer=TaskId.SerializeToString,
-        ),
-        'update_bucket': grpc.unary_unary_rpc_method_handler(
-            servicer.update_bucket,
-            request_deserializer=BucketName.FromString,
-            response_serializer=TaskId.SerializeToString,
-        ),
-        'remove_bucket': grpc.unary_unary_rpc_method_handler(
-            servicer.remove_bucket,
-            request_deserializer=BucketName.FromString,
-            response_serializer=BucketRemoved.SerializeToString,
-        ),
-        'exists_bucket': grpc.unary_unary_rpc_method_handler(
-            servicer.exists_bucket,
-            request_deserializer=BucketName.FromString,
-            response_serializer=BucketExists.SerializeToString,
-        ),
-        'get_assets': grpc.unary_unary_rpc_method_handler(
-            servicer.get_assets,
-            request_deserializer=BucketName.FromString,
-            response_serializer=Assets.SerializeToString,
-        ),
-    }
-    generic_handler = grpc.method_handlers_generic_handler(
-        'BucketService', rpc_method_handlers)
-    server.add_generic_rpc_handlers((generic_handler,))
-
-
-  class BetaAssetServiceServicer(object):
-    """The Beta API is deprecated for 0.15.0 and later.
-
-    It is recommended to use the GA API (classes and functions in this
-    file not marked beta) for all further purposes. This class was generated
-    only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0."""
-    # missing associated documentation comment in .proto file
-    pass
-    def get_asset(self, request, context):
-      # missing associated documentation comment in .proto file
-      pass
-      context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
-    def add_asset(self, request, context):
-      # missing associated documentation comment in .proto file
-      pass
-      context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
-    def update_asset(self, request, context):
-      # missing associated documentation comment in .proto file
-      pass
-      context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
-    def remove_asset(self, request, context):
-      # missing associated documentation comment in .proto file
-      pass
-      context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
-    def exists_asset(self, request, context):
-      # missing associated documentation comment in .proto file
-      pass
-      context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
-    def get_asset_info(self, request, context):
-      # missing associated documentation comment in .proto file
-      pass
-      context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
-    def get_task_state(self, request, context):
-      # missing associated documentation comment in .proto file
-      pass
-      context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
-    def get_bucket(self, request, context):
-      # missing associated documentation comment in .proto file
-      pass
-      context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
-    def query(self, request, context):
-      # missing associated documentation comment in .proto file
-      pass
-      context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
-
-
-  class BetaAssetServiceStub(object):
-    """The Beta API is deprecated for 0.15.0 and later.
-
-    It is recommended to use the GA API (classes and functions in this
-    file not marked beta) for all further purposes. This class was generated
-    only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0."""
-    # missing associated documentation comment in .proto file
-    pass
-    def get_asset(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
-      # missing associated documentation comment in .proto file
-      pass
-      raise NotImplementedError()
-    get_asset.future = None
-    def add_asset(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
-      # missing associated documentation comment in .proto file
-      pass
-      raise NotImplementedError()
-    add_asset.future = None
-    def update_asset(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
-      # missing associated documentation comment in .proto file
-      pass
-      raise NotImplementedError()
-    update_asset.future = None
-    def remove_asset(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
-      # missing associated documentation comment in .proto file
-      pass
-      raise NotImplementedError()
-    remove_asset.future = None
-    def exists_asset(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
-      # missing associated documentation comment in .proto file
-      pass
-      raise NotImplementedError()
-    exists_asset.future = None
-    def get_asset_info(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
-      # missing associated documentation comment in .proto file
-      pass
-      raise NotImplementedError()
-    get_asset_info.future = None
-    def get_task_state(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
-      # missing associated documentation comment in .proto file
-      pass
-      raise NotImplementedError()
-    get_task_state.future = None
-    def get_bucket(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
-      # missing associated documentation comment in .proto file
-      pass
-      raise NotImplementedError()
-    get_bucket.future = None
-    def query(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
-      # missing associated documentation comment in .proto file
-      pass
-      raise NotImplementedError()
-    query.future = None
-
-
-  def beta_create_AssetService_server(servicer, pool=None, pool_size=None, default_timeout=None, maximum_timeout=None):
-    """The Beta API is deprecated for 0.15.0 and later.
-
-    It is recommended to use the GA API (classes and functions in this
-    file not marked beta) for all further purposes. This function was
-    generated only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0"""
-    request_deserializers = {
-      ('AssetService', 'add_asset'): Asset.FromString,
-      ('AssetService', 'exists_asset'): TaskId.FromString,
-      ('AssetService', 'get_asset'): TaskId.FromString,
-      ('AssetService', 'get_asset_info'): TaskId.FromString,
-      ('AssetService', 'get_bucket'): TaskId.FromString,
-      ('AssetService', 'get_task_state'): TaskId.FromString,
-      ('AssetService', 'query'): Asset.FromString,
-      ('AssetService', 'remove_asset'): TaskId.FromString,
-      ('AssetService', 'update_asset'): Asset.FromString,
-    }
-    response_serializers = {
-      ('AssetService', 'add_asset'): TaskId.SerializeToString,
-      ('AssetService', 'exists_asset'): AssetExists.SerializeToString,
-      ('AssetService', 'get_asset'): Asset.SerializeToString,
-      ('AssetService', 'get_asset_info'): AssetInfo.SerializeToString,
-      ('AssetService', 'get_bucket'): Bucket.SerializeToString,
-      ('AssetService', 'get_task_state'): TaskState.SerializeToString,
-      ('AssetService', 'query'): Assets.SerializeToString,
-      ('AssetService', 'remove_asset'): AssetRemoved.SerializeToString,
-      ('AssetService', 'update_asset'): TaskId.SerializeToString,
-    }
-    method_implementations = {
-      ('AssetService', 'add_asset'): face_utilities.unary_unary_inline(servicer.add_asset),
-      ('AssetService', 'exists_asset'): face_utilities.unary_unary_inline(servicer.exists_asset),
-      ('AssetService', 'get_asset'): face_utilities.unary_unary_inline(servicer.get_asset),
-      ('AssetService', 'get_asset_info'): face_utilities.unary_unary_inline(servicer.get_asset_info),
-      ('AssetService', 'get_bucket'): face_utilities.unary_unary_inline(servicer.get_bucket),
-      ('AssetService', 'get_task_state'): face_utilities.unary_unary_inline(servicer.get_task_state),
-      ('AssetService', 'query'): face_utilities.unary_unary_inline(servicer.query),
-      ('AssetService', 'remove_asset'): face_utilities.unary_unary_inline(servicer.remove_asset),
-      ('AssetService', 'update_asset'): face_utilities.unary_unary_inline(servicer.update_asset),
-    }
-    server_options = beta_implementations.server_options(request_deserializers=request_deserializers, response_serializers=response_serializers, thread_pool=pool, thread_pool_size=pool_size, default_timeout=default_timeout, maximum_timeout=maximum_timeout)
-    return beta_implementations.server(method_implementations, options=server_options)
-
-
-  def beta_create_AssetService_stub(channel, host=None, metadata_transformer=None, pool=None, pool_size=None):
-    """The Beta API is deprecated for 0.15.0 and later.
-
-    It is recommended to use the GA API (classes and functions in this
-    file not marked beta) for all further purposes. This function was
-    generated only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0"""
-    request_serializers = {
-      ('AssetService', 'add_asset'): Asset.SerializeToString,
-      ('AssetService', 'exists_asset'): TaskId.SerializeToString,
-      ('AssetService', 'get_asset'): TaskId.SerializeToString,
-      ('AssetService', 'get_asset_info'): TaskId.SerializeToString,
-      ('AssetService', 'get_bucket'): TaskId.SerializeToString,
-      ('AssetService', 'get_task_state'): TaskId.SerializeToString,
-      ('AssetService', 'query'): Asset.SerializeToString,
-      ('AssetService', 'remove_asset'): TaskId.SerializeToString,
-      ('AssetService', 'update_asset'): Asset.SerializeToString,
-    }
-    response_deserializers = {
-      ('AssetService', 'add_asset'): TaskId.FromString,
-      ('AssetService', 'exists_asset'): AssetExists.FromString,
-      ('AssetService', 'get_asset'): Asset.FromString,
-      ('AssetService', 'get_asset_info'): AssetInfo.FromString,
-      ('AssetService', 'get_bucket'): Bucket.FromString,
-      ('AssetService', 'get_task_state'): TaskState.FromString,
-      ('AssetService', 'query'): Assets.FromString,
-      ('AssetService', 'remove_asset'): AssetRemoved.FromString,
-      ('AssetService', 'update_asset'): TaskId.FromString,
-    }
-    cardinalities = {
-      'add_asset': cardinality.Cardinality.UNARY_UNARY,
-      'exists_asset': cardinality.Cardinality.UNARY_UNARY,
-      'get_asset': cardinality.Cardinality.UNARY_UNARY,
-      'get_asset_info': cardinality.Cardinality.UNARY_UNARY,
-      'get_bucket': cardinality.Cardinality.UNARY_UNARY,
-      'get_task_state': cardinality.Cardinality.UNARY_UNARY,
-      'query': cardinality.Cardinality.UNARY_UNARY,
-      'remove_asset': cardinality.Cardinality.UNARY_UNARY,
-      'update_asset': cardinality.Cardinality.UNARY_UNARY,
-    }
-    stub_options = beta_implementations.stub_options(host=host, metadata_transformer=metadata_transformer, request_serializers=request_serializers, response_deserializers=response_deserializers, thread_pool=pool, thread_pool_size=pool_size)
-    return beta_implementations.dynamic_stub(channel, 'AssetService', cardinalities, options=stub_options)
-
-
-  class BetaBucketServiceServicer(object):
-    """The Beta API is deprecated for 0.15.0 and later.
-
-    It is recommended to use the GA API (classes and functions in this
-    file not marked beta) for all further purposes. This class was generated
-    only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0."""
-    # missing associated documentation comment in .proto file
-    pass
-    def add_bucket(self, request, context):
-      # missing associated documentation comment in .proto file
-      pass
-      context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
-    def update_bucket(self, request, context):
-      # missing associated documentation comment in .proto file
-      pass
-      context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
-    def remove_bucket(self, request, context):
-      # missing associated documentation comment in .proto file
-      pass
-      context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
-    def exists_bucket(self, request, context):
-      # missing associated documentation comment in .proto file
-      pass
-      context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
-    def get_assets(self, request, context):
-      # missing associated documentation comment in .proto file
-      pass
-      context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
-
-
-  class BetaBucketServiceStub(object):
-    """The Beta API is deprecated for 0.15.0 and later.
-
-    It is recommended to use the GA API (classes and functions in this
-    file not marked beta) for all further purposes. This class was generated
-    only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0."""
-    # missing associated documentation comment in .proto file
-    pass
-    def add_bucket(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
-      # missing associated documentation comment in .proto file
-      pass
-      raise NotImplementedError()
-    add_bucket.future = None
-    def update_bucket(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
-      # missing associated documentation comment in .proto file
-      pass
-      raise NotImplementedError()
-    update_bucket.future = None
-    def remove_bucket(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
-      # missing associated documentation comment in .proto file
-      pass
-      raise NotImplementedError()
-    remove_bucket.future = None
-    def exists_bucket(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
-      # missing associated documentation comment in .proto file
-      pass
-      raise NotImplementedError()
-    exists_bucket.future = None
-    def get_assets(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
-      # missing associated documentation comment in .proto file
-      pass
-      raise NotImplementedError()
-    get_assets.future = None
-
-
-  def beta_create_BucketService_server(servicer, pool=None, pool_size=None, default_timeout=None, maximum_timeout=None):
-    """The Beta API is deprecated for 0.15.0 and later.
-
-    It is recommended to use the GA API (classes and functions in this
-    file not marked beta) for all further purposes. This function was
-    generated only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0"""
-    request_deserializers = {
-      ('BucketService', 'add_bucket'): BucketName.FromString,
-      ('BucketService', 'exists_bucket'): BucketName.FromString,
-      ('BucketService', 'get_assets'): BucketName.FromString,
-      ('BucketService', 'remove_bucket'): BucketName.FromString,
-      ('BucketService', 'update_bucket'): BucketName.FromString,
-    }
-    response_serializers = {
-      ('BucketService', 'add_bucket'): TaskId.SerializeToString,
-      ('BucketService', 'exists_bucket'): BucketExists.SerializeToString,
-      ('BucketService', 'get_assets'): Assets.SerializeToString,
-      ('BucketService', 'remove_bucket'): BucketRemoved.SerializeToString,
-      ('BucketService', 'update_bucket'): TaskId.SerializeToString,
-    }
-    method_implementations = {
-      ('BucketService', 'add_bucket'): face_utilities.unary_unary_inline(servicer.add_bucket),
-      ('BucketService', 'exists_bucket'): face_utilities.unary_unary_inline(servicer.exists_bucket),
-      ('BucketService', 'get_assets'): face_utilities.unary_unary_inline(servicer.get_assets),
-      ('BucketService', 'remove_bucket'): face_utilities.unary_unary_inline(servicer.remove_bucket),
-      ('BucketService', 'update_bucket'): face_utilities.unary_unary_inline(servicer.update_bucket),
-    }
-    server_options = beta_implementations.server_options(request_deserializers=request_deserializers, response_serializers=response_serializers, thread_pool=pool, thread_pool_size=pool_size, default_timeout=default_timeout, maximum_timeout=maximum_timeout)
-    return beta_implementations.server(method_implementations, options=server_options)
-
-
-  def beta_create_BucketService_stub(channel, host=None, metadata_transformer=None, pool=None, pool_size=None):
-    """The Beta API is deprecated for 0.15.0 and later.
-
-    It is recommended to use the GA API (classes and functions in this
-    file not marked beta) for all further purposes. This function was
-    generated only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0"""
-    request_serializers = {
-      ('BucketService', 'add_bucket'): BucketName.SerializeToString,
-      ('BucketService', 'exists_bucket'): BucketName.SerializeToString,
-      ('BucketService', 'get_assets'): BucketName.SerializeToString,
-      ('BucketService', 'remove_bucket'): BucketName.SerializeToString,
-      ('BucketService', 'update_bucket'): BucketName.SerializeToString,
-    }
-    response_deserializers = {
-      ('BucketService', 'add_bucket'): TaskId.FromString,
-      ('BucketService', 'exists_bucket'): BucketExists.FromString,
-      ('BucketService', 'get_assets'): Assets.FromString,
-      ('BucketService', 'remove_bucket'): BucketRemoved.FromString,
-      ('BucketService', 'update_bucket'): TaskId.FromString,
-    }
-    cardinalities = {
-      'add_bucket': cardinality.Cardinality.UNARY_UNARY,
-      'exists_bucket': cardinality.Cardinality.UNARY_UNARY,
-      'get_assets': cardinality.Cardinality.UNARY_UNARY,
-      'remove_bucket': cardinality.Cardinality.UNARY_UNARY,
-      'update_bucket': cardinality.Cardinality.UNARY_UNARY,
-    }
-    stub_options = beta_implementations.stub_options(host=host, metadata_transformer=metadata_transformer, request_serializers=request_serializers, response_deserializers=response_deserializers, thread_pool=pool, thread_pool_size=pool_size)
-    return beta_implementations.dynamic_stub(channel, 'BucketService', cardinalities, options=stub_options)
-except ImportError:
-  pass
 # @@protoc_insertion_point(module_scope)

--- a/grpc_ssm/opac_pb2_grpc.py
+++ b/grpc_ssm/opac_pb2_grpc.py
@@ -24,6 +24,16 @@ class AssetServiceStub(object):
         request_serializer=opac__pb2.Asset.SerializeToString,
         response_deserializer=opac__pb2.TaskId.FromString,
         )
+    self.upload_file = channel.stream_unary(
+        '/AssetService/upload_file',
+        request_serializer=opac__pb2.File.SerializeToString,
+        response_deserializer=opac__pb2.Reply.FromString,
+        )
+    self.download_file = channel.unary_stream(
+        '/AssetService/download_file',
+        request_serializer=opac__pb2.Request.SerializeToString,
+        response_deserializer=opac__pb2.File.FromString,
+        )
     self.update_asset = channel.unary_unary(
         '/AssetService/update_asset',
         request_serializer=opac__pb2.Asset.SerializeToString,
@@ -73,6 +83,20 @@ class AssetServiceServicer(object):
     raise NotImplementedError('Method not implemented!')
 
   def add_asset(self, request, context):
+    # missing associated documentation comment in .proto file
+    pass
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def upload_file(self, request_iterator, context):
+    # missing associated documentation comment in .proto file
+    pass
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def download_file(self, request, context):
     # missing associated documentation comment in .proto file
     pass
     context.set_code(grpc.StatusCode.UNIMPLEMENTED)
@@ -140,6 +164,16 @@ def add_AssetServiceServicer_to_server(servicer, server):
           servicer.add_asset,
           request_deserializer=opac__pb2.Asset.FromString,
           response_serializer=opac__pb2.TaskId.SerializeToString,
+      ),
+      'upload_file': grpc.stream_unary_rpc_method_handler(
+          servicer.upload_file,
+          request_deserializer=opac__pb2.File.FromString,
+          response_serializer=opac__pb2.Reply.SerializeToString,
+      ),
+      'download_file': grpc.unary_stream_rpc_method_handler(
+          servicer.download_file,
+          request_deserializer=opac__pb2.Request.FromString,
+          response_serializer=opac__pb2.File.SerializeToString,
       ),
       'update_asset': grpc.unary_unary_rpc_method_handler(
           servicer.update_asset,


### PR DESCRIPTION
Criação de upload_file
Criação de download_file

Alteração em add_asset e update_asset
Se o servidor receber request.large_file_path em add_asset ou update_asset, registrará no SSM o conteúdo deste arquivo, ignorando o arquivo proveniente de request.file.

Alteração em get_asset
Se executar get_asset e o servidor identificar que asset.file é grande, retornará asset.file='' e asset.large_file_path = asset.file.path

No lado do cliente (opac_ssm_api), para arquivos grandes:
- a execução de add_asset e update_asset em duas etpas: primeiramente executando opac_ssm.upload_file que retorna o nome do arquivo grande e depois executando add_asset incluindo asset.large_file_path.
- a execução de get_asset também é em duas etapas: primeiramente executando opac_ssm.get_asset, depois executando opac_ssm.download_file, usando o arquivo identificado como asset.large_file_path.

Relacionado com
https://github.com/scieloorg/opac_ssm_api/issues/185

Fixes #390