### PR TITLE
Adiciona a capacidade de settar uma variável de ambiente para MEDIA_ROOT E MEDIA_URL.

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -198,10 +198,10 @@ STATICFILES_FINDERS = (
 # MEDIA CONFIGURATION
 # ------------------------------------------------------------------------------
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#media-root
-MEDIA_ROOT = str(APPS_DIR('media'))
+MEDIA_ROOT = env("DJANGO_MEDIA_ROOT", default=str(APPS_DIR('media')))
 
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#media-url
-MEDIA_URL = '/media/'
+MEDIA_URL = env("DJANGO_MEDIA_URL", default='/media/')
 
 # URL Configuration
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #418  

#### O que resolve este PR?
Adiciona a capacidade de alterar o caminho para a variável **MEDIA_ROOT** e **MEDIA_URL**.

#### Por onde começar a revisão:
Pelo arquivo **common.py**

##### Linha: **201** e **204**

#### Como deveria ser testado manualmente?

Teste local rodando o docker-compose-dev.yml.

#### Algum contexto adicional a considerar?
Não

#### Outros tickets relevantes?
N/A

#### Perguntas:
N/A